### PR TITLE
Confcalc configuration id for manifest

### DIFF
--- a/basemodels/__init__.py
+++ b/basemodels/__init__.py
@@ -92,6 +92,9 @@ class Manifest(Model):
     # If taskdata is separately stored
     taskdata_uri = URLType()
 
+    # Dict for experiment related attributes
+    experimental = DictType(StringType, required=False)
+
     def validate_taskdata_uri(self, data, value):
         if data.get('taskdata') and len(
                 data.get('taskdata')) > 0 and data.get('taskdata_uri'):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="hmt-basemodels",
-    version="0.0.1",
+    version="0.0.2",
     author="HUMAN Protocol",
     description="Basemodels for manifest data used by hmt-escrow",
     url="https://github.com/hCaptcha/hmt-basemodels",

--- a/test.py
+++ b/test.py
@@ -126,6 +126,15 @@ class ManifestTest(unittest.TestCase):
         self.assertGreater(
             len(manifest['requester_restricted_answer_set'].keys()), 0)
 
+    def test_experimental_dict_string(self):
+        """ Test that manifest contains experimental dict """
+        experimental_dict = {"test_key": 10, "test_key2": "asd"}
+        model = a_manifest()
+        model.experimental = experimental_dict
+        manifest = basemodels.Manifest(model)
+        manifest.validate()
+        self.assertListEqual(list(experimental_dict.keys()), list(manifest.experimental.keys()))
+
 
 if __name__ == "__main__":
     logging.basicConfig()


### PR DESCRIPTION
Adds configuration id to manifest. Key is not mandatory since default configuration is used if manifest doesn't contain the key.