### PR TITLE
Modify model to support verification data

### DIFF
--- a/basemodels/__init__.py
+++ b/basemodels/__init__.py
@@ -92,6 +92,7 @@ class Manifest(Model):
     request_config = ModelType(RequestConfig, required=False)
 
     # If taskdata is directly provided
+    taskdata = ListType(ModelType(TaskData))
     verification_data = ListType(ModelType(VerficationData))
 
     # If taskdata is separately stored

--- a/basemodels/__init__.py
+++ b/basemodels/__init__.py
@@ -4,7 +4,7 @@ from schematics.types import StringType, DecimalType, BooleanType, IntType, Dict
     UUIDType, ModelType, BooleanType
 
 class VerficationData(Model):
-    """ objects within taskdata list in Manifest """
+    """ objects within verification data list in Manifest """
     task_key = UUIDType(required=True)
     datapoint_uri = URLType(required=True, min_length=10)
     datapoint_hash = StringType(required=True, min_length=10)

--- a/basemodels/__init__.py
+++ b/basemodels/__init__.py
@@ -91,9 +91,6 @@ class Manifest(Model):
 
     request_config = ModelType(RequestConfig, required=False)
 
-    verifications = ListType(ModelType(TaskData))
-
-    
     # If taskdata is directly provided
     verification_data = ListType(ModelType(VerficationData))
 

--- a/basemodels/__init__.py
+++ b/basemodels/__init__.py
@@ -3,6 +3,11 @@ from schematics.models import Model, ValidationError
 from schematics.types import StringType, DecimalType, BooleanType, IntType, DictType, ListType, URLType, FloatType, \
     UUIDType, ModelType, BooleanType
 
+class VerficationData(Model):
+    """ objects within taskdata list in Manifest """
+    task_key = UUIDType(required=True)
+    datapoint_uri = URLType(required=True, min_length=10)
+    datapoint_hash = StringType(required=True, min_length=10)
 
 class TaskData(Model):
     """ objects within taskdata list in Manifest """
@@ -86,8 +91,11 @@ class Manifest(Model):
 
     request_config = ModelType(RequestConfig, required=False)
 
+    verifications = ListType(ModelType(TaskData))
+
+    
     # If taskdata is directly provided
-    taskdata = ListType(ModelType(TaskData))
+    verification_data = ListType(ModelType(VerficationData))
 
     # If taskdata is separately stored
     taskdata_uri = URLType()

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="hmt-basemodels",
-    version="0.0.2",
+    version="0.0.3",
     author="HUMAN Protocol",
     description="Basemodels for manifest data used by hmt-escrow",
     url="https://github.com/hCaptcha/hmt-basemodels",


### PR DESCRIPTION
In either case if the ground truth is 1-1 or not 1-1 in relationship with the taskdata, we still want to serve this  as two separate lists. 