### PR TITLE
Rem experimental key, add confcalc configuration id

### DIFF
--- a/basemodels/__init__.py
+++ b/basemodels/__init__.py
@@ -92,9 +92,6 @@ class Manifest(Model):
     # If taskdata is separately stored
     taskdata_uri = URLType()
 
-    # Dict for experiment related attributes
-    experimental = DictType(StringType, required=False)
-
     def validate_taskdata_uri(self, data, value):
         if data.get('taskdata') and len(
                 data.get('taskdata')) > 0 and data.get('taskdata_uri'):

--- a/basemodels/__init__.py
+++ b/basemodels/__init__.py
@@ -98,6 +98,9 @@ class Manifest(Model):
     # If taskdata is separately stored
     taskdata_uri = URLType()
 
+    # Configuration id
+    confcalc_configuration_id = StringType(required=False)
+
     def validate_taskdata_uri(self, data, value):
         if data.get('taskdata') and len(
                 data.get('taskdata')) > 0 and data.get('taskdata_uri'):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="hmt-basemodels",
-    version="0.0.2",
+    version="0.0.4",
     author="HUMAN Protocol",
     description="Basemodels for manifest data used by hmt-escrow",
     url="https://github.com/hCaptcha/hmt-basemodels",

--- a/test.py
+++ b/test.py
@@ -126,6 +126,13 @@ class ManifestTest(unittest.TestCase):
         self.assertGreater(
             len(manifest['requester_restricted_answer_set'].keys()), 0)
 
+    def test_confcalc_configuration_id(self):
+        """ Test that key is in manifest """
+        manifest = a_manifest()
+        manifest.confcalc_configuration_id = 'test_conf_id'
+        manifest.validate()
+
+
 if __name__ == "__main__":
     logging.basicConfig()
     logging.getLogger("urllib3").setLevel(logging.INFO)

--- a/test.py
+++ b/test.py
@@ -132,6 +132,27 @@ class ManifestTest(unittest.TestCase):
         manifest.confcalc_configuration_id = 'test_conf_id'
         manifest.validate()
 
+    def test_url_or_list_for_example(self):
+        """ validates that we can supply a list or a url to example key if ILB """
+        model = a_manifest()
+
+        model.requester_question_example = "https://test.com"
+        self.assertTrue(model.validate() is None)
+        self.assertIsInstance(model.to_primitive()['requester_question_example'], str)
+
+        model.requester_question_example = ["https://test.com"]
+        self.assertTrue(model.validate() is None)
+        self.assertIsInstance(model.to_primitive()['requester_question_example'], list)
+
+        model.requester_question_example = "non-url"
+        self.assertRaises(schematics.exceptions.DataError, model.validate)
+        model.requester_question_example = ["non-url"]
+        self.assertRaises(schematics.exceptions.DataError, model.validate)
+
+        # dont allow lists in non-ilb types
+        model.request_type = "image_label_area_select"
+        self.assertRaises(schematics.exceptions.DataError, model.validate)
+
 
 if __name__ == "__main__":
     logging.basicConfig()

--- a/test.py
+++ b/test.py
@@ -126,15 +126,6 @@ class ManifestTest(unittest.TestCase):
         self.assertGreater(
             len(manifest['requester_restricted_answer_set'].keys()), 0)
 
-    def test_experimental_dict_string(self):
-        """ Test that manifest contains experimental dict """
-        experimental_dict = {"test_key": 10, "test_key2": "asd"}
-        model = a_manifest()
-        model.experimental = experimental_dict
-        manifest = basemodels.Manifest(model)
-        manifest.validate()
-        self.assertListEqual(list(experimental_dict.keys()), list(manifest.experimental.keys()))
-
 
 if __name__ == "__main__":
     logging.basicConfig()


### PR DESCRIPTION
Experimental key not needed, lets remove it. More info [here](https://github.com/IntuitionMachines/hmt-servers/pull/2158)

Use `confcalc_configuration_id` instead