### PR TITLE
adds the ability to provide lists or url strings to example url in manifest

### DIFF
--- a/basemodels/__init__.py
+++ b/basemodels/__init__.py
@@ -1,8 +1,7 @@
 import uuid
 from schematics.models import Model, ValidationError
 from schematics.types import StringType, DecimalType, BooleanType, IntType, DictType, ListType, URLType, FloatType, \
-    UUIDType, ModelType, BooleanType
-from schematics.types import UnionType
+    UUIDType, ModelType, BooleanType, UnionType
 
 
 class TaskData(Model):

--- a/basemodels/__init__.py
+++ b/basemodels/__init__.py
@@ -2,6 +2,7 @@ import uuid
 from schematics.models import Model, ValidationError
 from schematics.types import StringType, DecimalType, BooleanType, IntType, DictType, ListType, URLType, FloatType, \
     UUIDType, ModelType, BooleanType
+from schematics.types import UnionType
 
 
 class TaskData(Model):
@@ -46,7 +47,13 @@ class Manifest(Model):
     requester_max_repeats = IntType(default=100)
     requester_min_repeats = IntType(default=1)
     requester_question = DictType(StringType)
-    requester_question_example = URLType()
+
+    requester_question_example = UnionType((URLType, ListType), field=URLType)
+    def validate_requester_question_example(self, data, value):
+        if data['request_type'] != 'image_label_binary' and isinstance(value, list):
+            raise ValidationError("Lists are not allowed in this challenge type")
+        return value
+
     unsafe_content = BooleanType(default=False)
     task_bid_price = DecimalType(required=True)
     oracle_stake = DecimalType(required=True)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="hmt-basemodels",
-    version="0.0.2",
+    version="0.0.3",
     author="HUMAN Protocol",
     description="Basemodels for manifest data used by hmt-escrow",
     url="https://github.com/hCaptcha/hmt-basemodels",

--- a/test.py
+++ b/test.py
@@ -135,6 +135,28 @@ class ManifestTest(unittest.TestCase):
         manifest.validate()
         self.assertListEqual(list(experimental_dict.keys()), list(manifest.experimental.keys()))
 
+    def test_url_or_list_for_example(self):
+        """ validates that we can supply a list or a url to example key if ILB """
+        model = a_manifest()
+
+        model.requester_question_example = "https://test.com"
+        self.assertTrue(model.validate() is None)
+        self.assertIsInstance(model.to_primitive()['requester_question_example'], str)
+
+        model.requester_question_example = ["https://test.com"]
+        self.assertTrue(model.validate() is None)
+        self.assertIsInstance(model.to_primitive()['requester_question_example'], list)
+
+        model.requester_question_example = "non-url"
+        self.assertRaises(schematics.exceptions.DataError, model.validate)
+        model.requester_question_example = ["non-url"]
+        self.assertRaises(schematics.exceptions.DataError, model.validate)
+
+        # dont allow lists in non-ilb types
+        model.request_type = "image_label_area_select"
+        self.assertRaises(schematics.exceptions.DataError, model.validate)
+
+
 
 if __name__ == "__main__":
     logging.basicConfig()


### PR DESCRIPTION
For now I restrict it to just ILB jobs as thats what we have support for on the frontend.

Related to similarity jobs and the new frontend challenge: https://github.com/hCaptcha/hcaptcha-v1/pull/262