### PR TITLE
add groundtruth_uri and groundtruth to manifest

### DIFF
--- a/basemodels/__init__.py
+++ b/basemodels/__init__.py
@@ -98,6 +98,9 @@ class Manifest(Model):
     # If taskdata is separately stored
     taskdata_uri = URLType()
 
+    # Groundtruth data is stored only as a URL
+    groundtruth_uri = URLType()
+
     # Configuration id
     confcalc_configuration_id = StringType(required=False)
 

--- a/basemodels/__init__.py
+++ b/basemodels/__init__.py
@@ -48,9 +48,12 @@ class Manifest(Model):
     requester_question = DictType(StringType)
 
     requester_question_example = UnionType((URLType, ListType), field=URLType)
+
     def validate_requester_question_example(self, data, value):
-        if data['request_type'] != 'image_label_binary' and isinstance(value, list):
-            raise ValidationError("Lists are not allowed in this challenge type")
+        if data['request_type'] != 'image_label_binary' and isinstance(
+                value, list):
+            raise ValidationError(
+                "Lists are not allowed in this challenge type")
         return value
 
     unsafe_content = BooleanType(default=False)
@@ -98,8 +101,15 @@ class Manifest(Model):
     # If taskdata is separately stored
     taskdata_uri = URLType()
 
-    # Groundtruth data is stored only as a URL
-    groundtruth_uri = URLType()
+    # Groundtruth data is stored as a URL or optionally as an inlined json-serialized stringtype
+    groundtruth_uri = URLType(required=False)
+    groundtruth = StringType(required=False)
+
+    def validate_groundtruth(self, data, value):
+        if data.get('groundtruth_uri') and data.get('groundtruth'):
+            raise ValidationError(
+                "Specify only groundtruth_uri or groundtruth, not both.")
+        return value
 
     # Configuration id
     confcalc_configuration_id = StringType(required=False)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="hmt-basemodels",
-    version="0.0.4",
+    version="0.0.5",
     author="HUMAN Protocol",
     description=
     "Common data models shared by various components of the Human Protocol stack",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,8 @@ setuptools.setup(
     name="hmt-basemodels",
     version="0.0.4",
     author="HUMAN Protocol",
-    description="Common data models shared by various components of the Human Protocol stack",
+    description=
+    "Common data models shared by various components of the Human Protocol stack",
     url="https://github.com/hCaptcha/hmt-basemodels",
     include_package_data=True,
     zip_safe=True,

--- a/test.py
+++ b/test.py
@@ -138,11 +138,13 @@ class ManifestTest(unittest.TestCase):
 
         model.requester_question_example = "https://test.com"
         self.assertTrue(model.validate() is None)
-        self.assertIsInstance(model.to_primitive()['requester_question_example'], str)
+        self.assertIsInstance(
+            model.to_primitive()['requester_question_example'], str)
 
         model.requester_question_example = ["https://test.com"]
         self.assertTrue(model.validate() is None)
-        self.assertIsInstance(model.to_primitive()['requester_question_example'], list)
+        self.assertIsInstance(
+            model.to_primitive()['requester_question_example'], list)
 
         model.requester_question_example = "non-url"
         self.assertRaises(schematics.exceptions.DataError, model.validate)


### PR DESCRIPTION
We need to add a pointer to the manifest for RecO / Chunkbroker to fetch the regularized groundtruth serialized and encrypted by loader. Tentatively supporting literal unencrypted serialization of the groundtruth as a stringtype for debug, although I intend to remove `groundtruth` before this is used fulltime.