### PR TITLE
Restricted audience

### DIFF
--- a/basemodels/__init__.py
+++ b/basemodels/__init__.py
@@ -23,11 +23,6 @@ class RequestConfig(Model):
     restrict_to_coords = BooleanType()
     minimum_selection_area_per_shape = IntType()
 
-class RestrictedAudience(Model):
-    """ definition of the restricted_audience object in manifest """
-    minimum_client_confidence = FloatType(required=False)
-    lang = StringType(required=False)
-
 class Manifest(Model):
     """ The manifest description. """
     job_mode = StringType(

--- a/basemodels/__init__.py
+++ b/basemodels/__init__.py
@@ -1,7 +1,7 @@
 import uuid
 from schematics.models import Model, ValidationError
 from schematics.types import StringType, DecimalType, BooleanType, IntType, DictType, ListType, URLType, FloatType, \
-    UUIDType, ModelType, BooleanType, UnionType
+    UUIDType, ModelType, BooleanType, UnionType, MultiType
 
 
 class TaskData(Model):
@@ -23,6 +23,10 @@ class RequestConfig(Model):
     restrict_to_coords = BooleanType()
     minimum_selection_area_per_shape = IntType()
 
+class RestrictedAudience(Model):
+    """ definition of the restricted_audience object in manifest """
+    minimum_client_confidence = FloatType(required=False)
+    lang = StringType(required=False)
 
 class Manifest(Model):
     """ The manifest description. """
@@ -113,6 +117,8 @@ class Manifest(Model):
 
     # Configuration id
     confcalc_configuration_id = StringType(required=False)
+
+    restricted_audience = ModelType(RestrictedAudience, required=False)
 
     def validate_taskdata_uri(self, data, value):
         if data.get('taskdata') and len(

--- a/basemodels/__init__.py
+++ b/basemodels/__init__.py
@@ -118,7 +118,7 @@ class Manifest(Model):
     # Configuration id
     confcalc_configuration_id = StringType(required=False)
 
-    restricted_audience = ModelType(RestrictedAudience, required=False)
+    restricted_audience = DictType(ListType(DictType(DictType(FloatType))))
 
     def validate_taskdata_uri(self, data, value):
         if data.get('taskdata') and len(

--- a/basemodels/__init__.py
+++ b/basemodels/__init__.py
@@ -1,7 +1,7 @@
 import uuid
 from schematics.models import Model, ValidationError
 from schematics.types import StringType, DecimalType, BooleanType, IntType, DictType, ListType, URLType, FloatType, \
-    UUIDType, ModelType, BooleanType, UnionType, MultiType
+    UUIDType, ModelType, BooleanType, UnionType
 
 
 class TaskData(Model):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="hmt-basemodels",
-    version="0.0.5",
+    version="0.0.6",
     author="HUMAN Protocol",
     description=
     "Common data models shared by various components of the Human Protocol stack",

--- a/test.py
+++ b/test.py
@@ -162,12 +162,12 @@ class ManifestTest(unittest.TestCase):
         manifest = a_manifest()
         manifest.restricted_audience = {
             "lang": [{"en-us": {"score": 0.9}}],
-            "client": [{"minimum_confidence": {"score": 0.9}}]
+            "confidence": [{"minimum_client_confidence": {"score": 0.9}}]
         }
         manifest.validate()
         self.assertTrue("restricted_audience" in manifest.to_primitive())
-        self.assertTrue("minimum_confidence" in manifest.to_primitive()["restricted_audience"]["client"][0])
-        self.assertEqual(0.9, manifest.to_primitive()["restricted_audience"]["client"][0]["minimum_confidence"]["score"])
+        self.assertTrue("minimum_client_confidence" in manifest.to_primitive()["restricted_audience"]["confidence"][0])
+        self.assertEqual(0.9, manifest.to_primitive()["restricted_audience"]["confidence"][0]["minimum_client_confidence"]["score"])
         self.assertTrue("en-us" in manifest.to_primitive()["restricted_audience"]["lang"][0])
         self.assertEqual(0.9, manifest.to_primitive()["restricted_audience"]["lang"][0]["en-us"]["score"])
 

--- a/test.py
+++ b/test.py
@@ -132,6 +132,8 @@ class ManifestTest(unittest.TestCase):
         manifest.confcalc_configuration_id = 'test_conf_id'
         manifest.validate()
 
+        self.assertTrue("confcalc_configuration_id" in manifest.to_primitive())
+
     def test_url_or_list_for_example(self):
         """ validates that we can supply a list or a url to example key if ILB """
         model = a_manifest()
@@ -155,6 +157,17 @@ class ManifestTest(unittest.TestCase):
         model.request_type = "image_label_area_select"
         self.assertRaises(schematics.exceptions.DataError, model.validate)
 
+    def test_restricted_audience(self):
+        """ Test that restricted audience is in the Manifest """
+        manifest = a_manifest()
+        manifest.restricted_audience = {
+            "minimum_client_confidence": 0.3,
+            "lang": "en-us"
+        }
+        manifest.validate()
+        self.assertTrue("restricted_audience" in manifest.to_primitive())
+        self.assertTrue("minimum_client_confidence" in manifest.to_primitive()["restricted_audience"])
+        self.assertTrue("lang" in manifest.to_primitive()["restricted_audience"])
 
 if __name__ == "__main__":
     logging.basicConfig()

--- a/test.py
+++ b/test.py
@@ -161,13 +161,15 @@ class ManifestTest(unittest.TestCase):
         """ Test that restricted audience is in the Manifest """
         manifest = a_manifest()
         manifest.restricted_audience = {
-            "minimum_client_confidence": 0.3,
-            "lang": "en-us"
+            "lang": [{"en-us": {"score": 0.9}}],
+            "client": [{"minimum_confidence": {"score": 0.9}}]
         }
         manifest.validate()
         self.assertTrue("restricted_audience" in manifest.to_primitive())
-        self.assertTrue("minimum_client_confidence" in manifest.to_primitive()["restricted_audience"])
-        self.assertTrue("lang" in manifest.to_primitive()["restricted_audience"])
+        self.assertTrue("minimum_confidence" in manifest.to_primitive()["restricted_audience"]["client"][0])
+        self.assertEqual(0.9, manifest.to_primitive()["restricted_audience"]["client"][0]["minimum_confidence"]["score"])
+        self.assertTrue("en-us" in manifest.to_primitive()["restricted_audience"]["lang"][0])
+        self.assertEqual(0.9, manifest.to_primitive()["restricted_audience"]["lang"][0]["en-us"]["score"])
 
 if __name__ == "__main__":
     logging.basicConfig()


### PR DESCRIPTION
Adds restricted audience to manifest. Fields that exist in the whitepaper, lang and minimum client confidence, are added. 