### PR TITLE
Webhook configuration to manifest

### DIFF
--- a/basemodels/__init__.py
+++ b/basemodels/__init__.py
@@ -125,6 +125,8 @@ class NestedManifest(Model):
     # Configuration id
     confcalc_configuration_id = StringType(required=False)
 
+    webhook = ModelType(Webhook)
+
 
 class Manifest(Model):
     """ The manifest description. """

--- a/basemodels/__init__.py
+++ b/basemodels/__init__.py
@@ -38,6 +38,17 @@ def validate_request_type(self, data, value):
 
     return value
 
+class Webhook(Model):
+    """ Model for webhook configuration """
+    webhook_id = UUIDType(required=True)
+    chunk_completed = ListType(URLType(), required=False)
+    job_completed = ListType(URLType(), required=False)
+
+    # States that might be interesting later
+    # job_skipped = ListType(URLType(), required=False)
+    # job_inserted = ListType(URLType(), required=False)
+    # job_activated = ListType(URLType(), required=False)
+
 
 class TaskData(Model):
     """ objects within taskdata list in Manifest """
@@ -205,3 +216,5 @@ class Manifest(Model):
         return value
 
     validate_taskdata = validate_taskdata_uri
+
+    webhook = ModelType(Webhook)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="hmt-basemodels",
-    version="0.0.9",
+    version="0.0.10",
     author="HUMAN Protocol",
     description="Common data models shared by various components of the Human Protocol stack",
     url="https://github.com/hCaptcha/hmt-basemodels",

--- a/test.py
+++ b/test.py
@@ -324,6 +324,18 @@ class ManifestTest(unittest.TestCase):
         # print(model.to_primitive())
         self.assertTrue(model.validate() is None)
 
+    def test_webhook(self):
+        """ Test that webhook is correct """
+        webhook = {
+            "webhook_id": "c26c2e6a-41ab-4218-b39e-6314b760c45c",
+            "chunk_completed": [],
+            "job_completed": ["http://test.com"]
+        }
+
+        model = basemodels.Webhook(webhook)
+        model.validate()
+
+        self.assertTrue("webhook_id" in model.to_primitive())
 
 if __name__ == "__main__":
     logging.basicConfig()

--- a/test.py
+++ b/test.py
@@ -328,14 +328,28 @@ class ManifestTest(unittest.TestCase):
         """ Test that webhook is correct """
         webhook = {
             "webhook_id": "c26c2e6a-41ab-4218-b39e-6314b760c45c",
-            "chunk_completed": [],
             "job_completed": ["http://test.com"]
         }
 
-        model = basemodels.Webhook(webhook)
-        model.validate()
+        webhook_model = basemodels.Webhook(webhook)
+        webhook_model.validate()
+        self.assertTrue("webhook_id" in webhook_model.to_primitive())
 
-        self.assertTrue("webhook_id" in model.to_primitive())
+        model = a_manifest()
+        model.webhook = webhook
+        model.validate()
+        self.assertTrue("webhook" in model.to_primitive())
+
+    def test_webhook_url_broken(self):
+        """ Test that webhook validation fails if url is broken """
+        webhook = {
+            "webhook_id": "c26c2e6a-41ab-4218-b39e-6314b760c45c",
+            "job_completed": ["not-a-url"]
+        }
+
+        webhook_model = basemodels.Webhook(webhook)
+        self.assertRaises(schematics.exceptions.DataError, webhook_model.validate)
+
 
 if __name__ == "__main__":
     logging.basicConfig()


### PR DESCRIPTION
Add webhook configuration to basemodels. Every events needs to be defined, if webhook events is wanted - no wildcard functionality exists.

I added issue #20 while doing this, but it's not required for this pr.