### PR TITLE
Relax url validation

### DIFF
--- a/basemodels/__init__.py
+++ b/basemodels/__init__.py
@@ -41,13 +41,13 @@ def validate_request_type(self, data, value):
 class Webhook(Model):
     """ Model for webhook configuration """
     webhook_id = UUIDType(required=True)
-    chunk_completed = ListType(URLType(), required=False)
-    job_completed = ListType(URLType(), required=False)
+    chunk_completed = ListType(StringType(), required=False)
+    job_completed = ListType(StringType(), required=False)
 
     # States that might be interesting later
-    # job_skipped = ListType(URLType(), required=False)
-    # job_inserted = ListType(URLType(), required=False)
-    # job_activated = ListType(URLType(), required=False)
+    # job_skipped = ListType(StringType(), required=False)
+    # job_inserted = ListType(StringType(), required=False)
+    # job_activated = ListType(StringType(), required=False)
 
 
 class TaskData(Model):

--- a/test.py
+++ b/test.py
@@ -328,7 +328,7 @@ class ManifestTest(unittest.TestCase):
         """ Test that webhook is correct """
         webhook = {
             "webhook_id": "c26c2e6a-41ab-4218-b39e-6314b760c45c",
-            "job_completed": ["http://test.com"]
+            "job_completed": ["http://servicename:4000/api/webhook"]
         }
 
         webhook_model = basemodels.Webhook(webhook)
@@ -339,16 +339,6 @@ class ManifestTest(unittest.TestCase):
         model.webhook = webhook
         model.validate()
         self.assertTrue("webhook" in model.to_primitive())
-
-    def test_webhook_url_broken(self):
-        """ Test that webhook validation fails if url is broken """
-        webhook = {
-            "webhook_id": "c26c2e6a-41ab-4218-b39e-6314b760c45c",
-            "job_completed": ["not-a-url"]
-        }
-
-        webhook_model = basemodels.Webhook(webhook)
-        self.assertRaises(schematics.exceptions.DataError, webhook_model.validate)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Inside cluster kubernetes services can be reached with this type of URLs `http://servicename:4000/api/webhook`. `Schematics`' url validation doesn't accepts this type of url. For that reason validation criterion needs to be relaxed and now only type is checked to be a string.