### PR TITLE
Add GroundTruth models #30

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,10 +6,12 @@ verify_ssl = true
 [dev-packages]
 yapf = "==0.25.0"
 mypy = "==0.670"
+httpretty = "*"
 
 [packages]
 schematics = "*"
 marshmallow = "*"
+requests = "*"
 
 [requires]
 python_version = "3.6"

--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ httpretty = "*"
 schematics = "*"
 marshmallow = "*"
 requests = "*"
+ijson = "*"
 
 [requires]
 python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1c4e4c8b0128cc0b1975a5e00e50d6248d8e7f33af19a10e634377bdfffbfbd5"
+            "sha256": "fedbcc056fcd8eb2dd001716ea0ffdf3c9fd91753f519136721b18b57557b157"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -36,6 +36,32 @@
                 "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"
             ],
             "version": "==2.9"
+        },
+        "ijson": {
+            "hashes": [
+                "sha256:077151d61e4760e4281ba4f8639f7ed5b3ce93ec0b51e6648485a39b2ed449d8",
+                "sha256:0d7fd00900493497e58b7873a53ff6f27a7070875f285d4e7d80a5c62d745f80",
+                "sha256:176c6638351cad63d4cd803237185e9e79656527498f527e1adcff839540c08f",
+                "sha256:244606e042bb836d75be6c9d890ca9cf5774ffee6306337c73624b5252e97cc9",
+                "sha256:2589c757fec65b07a459af630059766149cdde3ff1c3a171a726a7b5842fbcf5",
+                "sha256:29b44c7ae1a7a3dc27d835e6bf23c6c07350eacd7b13b54ace16fe6d167ff684",
+                "sha256:3925cff93a904423d4284855990dd386aa524304d4cb8ec7b3afc78e34de1ec6",
+                "sha256:40dc2826a340737de2927a6523ce722fff187811c06b744cf69e09de9a0aa79e",
+                "sha256:4113be2f0332d15a13fb8599655218678eace0bebd736a8ba3ef8856ce0e74c6",
+                "sha256:4fb8dd9b12f6996442a69012375886e7393d57c0c0b6185bf191d6e6d4d9394d",
+                "sha256:68ffb77e234eabba3d4c98d8f3c9c14d971cbe6ffc5a703f252dbf73163d857e",
+                "sha256:6e25448318cda55e82a5de52beb6813b003cb8e4a7b5753305912a30055a29f8",
+                "sha256:7cdd8de953e2782fdedccc01e3b22cd1bc1c3e92cf253c27daf7c65e62fd0a53",
+                "sha256:8389eddab9abc19145995d9d485bfc5cba8fd6b18b14b36106e0ac7ae689d345",
+                "sha256:9a1dbfa2887caf50022ee5ee226d9dd347498da63bbf3ed8e655aa4826240977",
+                "sha256:9bb773fc34a4c6b60d31329063f9bf870e238bbe619c6b9805bfb4ba5f12472e",
+                "sha256:9cf47e65eec4ce5b94c5c71888c3356537394b17e24d9c9b47e3a5eef124c41e",
+                "sha256:c9bf76a3d54280bb0a2c45d475dc822ab35f265824f336977843f0b2e5e4de39",
+                "sha256:d045d2cb728d4553b7eca0c9464888ea181dfa65e16dacf8b369fcd7757bc1fa",
+                "sha256:ee8544d2ca4f39ae6f920be72022bb7f3928639bc4767bd0299a44b2005df3fe"
+            ],
+            "index": "pypi",
+            "version": "==3.0.4"
         },
         "marshmallow": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f942d0d3f223a304896910a4849c9b8c75e12422fd57c726f097638234f63645"
+            "sha256": "1c4e4c8b0128cc0b1975a5e00e50d6248d8e7f33af19a10e634377bdfffbfbd5"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,13 +16,42 @@
         ]
     },
     "default": {
+        "certifi": {
+            "hashes": [
+                "sha256:1d987a998c75633c40847cc966fcf5904906c920a7f17ef374f5aa4282abd304",
+                "sha256:51fcb31174be6e6664c5f69e3e1691a2d72a1a12e90f872cbdb1567eb47b6519"
+            ],
+            "version": "==2020.4.5.1"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb",
+                "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"
+            ],
+            "version": "==2.9"
+        },
         "marshmallow": {
             "hashes": [
-                "sha256:7669b944d6233b81f68739d5826f1176c3841cc31cf6b856841083b5a72f5ca9",
-                "sha256:c9d277f6092f32300395fb83d343be9f61b5e99d66d22bae1e5e7cd82608fee6"
+                "sha256:c2673233aa21dde264b84349dc2fd1dce5f30ed724a0a00e75426734de5b84ab",
+                "sha256:f88fe96434b1f0f476d54224d59333eba8ca1a203a2695683c1855675c4049a7"
             ],
             "index": "pypi",
-            "version": "==3.4.0"
+            "version": "==3.6.0"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee",
+                "sha256:b3f43d496c6daba4493e7c431722aeb7dbc6288f52a6e04e7b6023b0247817e6"
+            ],
+            "index": "pypi",
+            "version": "==2.23.0"
         },
         "schematics": {
             "hashes": [
@@ -31,9 +60,23 @@
             ],
             "index": "pypi",
             "version": "==2.1.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527",
+                "sha256:88206b0eb87e6d677d424843ac5209e3fb9d0190d0ee169599165ec25e9d9115"
+            ],
+            "version": "==1.25.9"
         }
     },
     "develop": {
+        "httpretty": {
+            "hashes": [
+                "sha256:24a6fd2fe1c76e94801b74db8f52c0fb42718dc4a199a861b305b1a492b9d868"
+            ],
+            "index": "pypi",
+            "version": "==1.0.2"
+        },
         "mypy": {
             "hashes": [
                 "sha256:308c274eb8482fbf16006f549137ddc0d69e5a589465e37b99c4564414363ca7",

--- a/basemodels/__init__.py
+++ b/basemodels/__init__.py
@@ -1,2 +1,4 @@
-from .manifest import Manifest, NestedManifest, RequestConfig, TaskData, Webhook
+from .manifest import validate_manifest_uris, Manifest, NestedManifest, RequestConfig, TaskData, Webhook
 from .via import ViaDataManifest
+from .groundtruth import get_groundtruth_model, ILASGroundtruth, ILBGroundtruth
+from .taskdata import get_taskdata_model, TaskDataList

--- a/basemodels/__init__.py
+++ b/basemodels/__init__.py
@@ -1,4 +1,5 @@
 from .manifest import validate_manifest_uris, Manifest, NestedManifest, RequestConfig, TaskData, Webhook
 from .via import ViaDataManifest
-from .groundtruth import get_groundtruth_model, ILASGroundtruth, ILBGroundtruth
-from .taskdata import get_taskdata_model, TaskDataList
+from .groundtruth import validate_groundtruth_entry
+from .taskdata import validate_taskdata_entry
+from .streaming_json import traverse_json_uri

--- a/basemodels/groundtruth.py
+++ b/basemodels/groundtruth.py
@@ -1,0 +1,64 @@
+from typing import Union
+from schematics.models import Model
+from schematics.types import StringType, ListType, URLType, BaseType, ModelType, IntType, FloatType, DictType, UnionType
+
+
+class ILBGroundtruth(Model):
+    """
+    Groundtruth file format for `image_label_binary` job type:
+
+    {
+      "https://domain.com/file1.jpeg": ["false", "false", "false"],
+      "https://domain.com/file2.jpeg": ["true", "true", "true"]
+    }
+    """
+    items = BaseType()
+
+    def validate_items(self, data, value):
+        for k, v in value.items():
+            URLType().validate(k)
+            ListType(StringType(choices=["true", "false"])).validate(v)
+
+
+class ILASGroundtruthDatapoint(Model):
+    coords = ListType(UnionType([IntType, FloatType]))
+
+
+class ILASGroundtruth(Model):
+    """
+    Groundtruth file format for `image_label_area_select` job type
+
+    {
+      "datapoints": [
+        {
+          "https://domain.com/file1.jpeg": {
+            "coords": [303, 183]
+          }
+        },
+        {
+          "https://domain.com/file1.jpeg": {
+            "coords": [361, 239]
+          }
+        }
+      ]
+    }
+    """
+    datapoints = ListType(DictType(ModelType(ILASGroundtruthDatapoint)), required=True)
+
+    def validate_datapoints(self, data, value):
+        for datapoint in value:
+            for key in datapoint.keys():
+                URLType().validate(key)
+
+
+def get_groundtruth_model(data: Union[dict, list], request_type: str,
+                          **kwargs) -> Union[None, ILBGroundtruth, ILASGroundtruth]:
+    """
+    Create appropriate groundtruth model based on request_type
+    """
+    if request_type == 'image_label_binary':
+        return ILBGroundtruth({"items": data})
+    elif request_type == 'image_label_area_select':
+        return ILASGroundtruth(data)
+
+    return None

--- a/basemodels/streaming_json.py
+++ b/basemodels/streaming_json.py
@@ -1,0 +1,41 @@
+import ijson
+from typing import Callable
+from urllib.request import urlopen
+
+
+def traverse_json_uri(uri: str, callback: Callable) -> int:
+  """
+    Traverse remote json using streaming api & callback for each top-level entry
+  """
+
+  builder = ijson.common.ObjectBuilder()
+  depth = -1
+  entry_key = None
+  entries_count = 0
+
+  for event, value in ijson.basic_parse(urlopen(uri)):
+      if event == 'start_map' or event == 'start_array':
+          # Skip top level json container
+          if depth == -1:
+              depth += 1
+              continue
+
+          depth += 1
+
+      if event == 'end_map' or event == 'end_array':
+          depth -= 1
+
+          # End of top-level entry, callback
+          if depth == 0:
+              callback(builder.value, entry_key)
+              entries_count += 1
+
+      if event == 'map_key':
+          # Save entry's key for key-value json
+          if depth == 0:
+              entry_key = value
+
+      # Consume parsing event
+      builder.event(event, value)
+
+  return entries_count

--- a/basemodels/taskdata.py
+++ b/basemodels/taskdata.py
@@ -1,14 +1,8 @@
-from schematics.models import Model
+from schematics.models import Model, ValidationError
 from schematics.types import ListType, ModelType, UUIDType, URLType, StringType
 
 
-class TaskData(Model):
-    task_key = UUIDType(required=True)
-    datapoint_uri = URLType(required=True, min_length=10)
-    datapoint_hash = StringType(required=True, min_length=10)
-
-
-class TaskDataList(Model):
+class TaskDataEntry(Model):
     """
     Taskdata file format:
 
@@ -25,8 +19,14 @@ class TaskDataList(Model):
       }
     ]
     """
-    items = ListType(ModelType(TaskData))
+    task_key = UUIDType()
+    datapoint_uri = URLType(required=True, min_length=10)
+    datapoint_hash = StringType()
 
 
-def get_taskdata_model(data: list, **kwargs) -> TaskDataList:
-    return TaskDataList({"items": data})
+def validate_taskdata_entry(value: dict):
+    """ Validate taskdata entry """
+    if not isinstance(value, dict):
+        raise ValidationError("taskdata entry should be dict")
+
+    TaskDataEntry(value).validate()

--- a/basemodels/taskdata.py
+++ b/basemodels/taskdata.py
@@ -1,0 +1,32 @@
+from schematics.models import Model
+from schematics.types import ListType, ModelType, UUIDType, URLType, StringType
+
+
+class TaskData(Model):
+    task_key = UUIDType(required=True)
+    datapoint_uri = URLType(required=True, min_length=10)
+    datapoint_hash = StringType(required=True, min_length=10)
+
+
+class TaskDataList(Model):
+    """
+    Taskdata file format:
+
+    [
+      {
+        "task_key": "407fdd93-687a-46bb-b578-89eb96b4109d",
+        "datapoint_uri": "https://domain.com/file1.jpg",
+        "datapoint_hash": "f4acbe8562907183a484498ba901bfe5c5503aaa"
+      },
+      {
+        "task_key": "20bd4f3e-4518-4602-b67a-1d8dfabcce0c",
+        "datapoint_uri": "https://domain.com/file2.jpg",
+        "datapoint_hash": "f4acbe8562907183a484498ba901bfe5c5503aaa"
+      }
+    ]
+    """
+    items = ListType(ModelType(TaskData))
+
+
+def get_taskdata_model(data: list, **kwargs) -> TaskDataList:
+    return TaskDataList({"items": data})

--- a/setup.py
+++ b/setup.py
@@ -13,4 +13,4 @@ setuptools.setup(
         "Programming Language :: Python"
     ],
     packages=setuptools.find_packages(),
-    install_requires=["schematics>=2.1.0", "marshmallow>=3.2.1"])
+    install_requires=["schematics>=2.1.0", "marshmallow>=3.2.1", "requests>=2"])

--- a/test.py
+++ b/test.py
@@ -6,6 +6,7 @@ import sys
 import schematics
 import basemodels
 import unittest
+import httpretty
 import json
 
 CALLBACK_URL = "http://google.com/webback"
@@ -412,6 +413,243 @@ class ViaTest(unittest.TestCase):
         self.assertEqual(len(parsed['datapoints']), 1)
         self.assertEqual(parsed['version'], 1)
         self.assertIn('dog', parsed['datapoints'][0]['class_attributes'])
+
+
+class GetGroundtruthModelTest(unittest.TestCase):
+    def test_get_groundtruth_model_unknown(self):
+        """ should return None for unknown request_type """
+        model = basemodels.get_groundtruth_model({}, '')
+        self.assertIsNone(model)
+
+    def test_get_groundtruth_model_ilas(self):
+        """ should return ILASGroundtruth for image_label_area_select """
+        model = basemodels.get_groundtruth_model({}, 'image_label_area_select')
+        self.assertIsInstance(model, basemodels.ILASGroundtruth)
+
+    def test_get_groundtruth_model_ilb(self):
+        """ should return ILBGroundtruth for image_label_binary """
+        model = basemodels.get_groundtruth_model({}, 'image_label_binary')
+        self.assertIsInstance(model, basemodels.ILBGroundtruth)
+
+
+class ILBGroundtruthTest(unittest.TestCase):
+    def validate_gt(self, data):
+        basemodels.get_groundtruth_model(data, 'image_label_binary').validate()
+
+    def test_ilb_gt_valid(self):
+        """ should not raise for valid gt format """
+        gt = {
+            "https://domain.com/123/file1.jpeg": ["false", "false", "false"],
+            "https://domain.com/456/file2.jpeg": ["false", "true", "false"],
+        }
+
+        self.validate_gt(gt)
+
+    def test_ilb_gt_invalid_keys(self):
+        """ should raise DataError for invalid url key """
+        gt = {
+            "not_url": ["false", "false", "false"],
+            "https://domain.com/456/file2.jpeg": ["false", "true", "false"],
+        }
+
+        with self.assertRaises(schematics.exceptions.DataError):
+            self.validate_gt(gt)
+
+    def test_ilb_gt_invalid_list_values(self):
+        """ should raise CompoundError for invalid values """
+        gt = {
+            "https://domain.com/456/file2.jpeg": [False, True, 1],
+        }
+
+        with self.assertRaises(schematics.exceptions.CompoundError):
+            self.validate_gt(gt)
+
+
+class ILASGroundtruthDatapointTest(unittest.TestCase):
+    def validate_gt(self, data):
+        basemodels.get_groundtruth_model(data, 'image_label_area_select').validate()
+
+    def test_ilas_gt_valid(self):
+        """ should not raise for valid gt format """
+        gt = {
+            "datapoints": [{
+                "https://domain.com/file1.jpeg": {
+                    "coords": [303, 183]
+                }
+            }, {
+                "https://domain.com/file1.jpeg": {
+                    "coords": [361, 239]
+                }
+            }]
+        }
+
+        self.validate_gt(gt)
+
+    def test_ilas_gt_invalid_keys(self):
+        """ should raise DataError for invalid url key """
+        gt = {
+            "datapoints": [{
+                "not_url": {
+                    "coords": [303, 183]
+                }
+            }, {
+                "https://domain.com/file1.jpeg": {
+                    "coords": [361, 239]
+                }
+            }]
+        }
+
+        with self.assertRaises(schematics.exceptions.DataError):
+            self.validate_gt(gt)
+
+    def test_ilas_gt_invalid_values(self):
+        """ should raise DataError for invalid value """
+        gt = {"datapoints": [{"https://domain.com/file1.jpeg": 1}]}
+
+        with self.assertRaises(schematics.exceptions.DataError):
+            self.validate_gt(gt)
+
+
+class GetTaskDataModelTest(unittest.TestCase):
+    def test_get_taskdata_model(self):
+        """ should return TaskDataList model """
+        model = basemodels.get_taskdata_model([])
+        self.assertIsInstance(model, basemodels.TaskDataList)
+
+
+class TaskDataListTest(unittest.TestCase):
+    def validate_taskdata(self, data):
+        basemodels.get_taskdata_model(data).validate()
+
+    def test_taskdata_valid(self):
+        """ should not raise for valid taskdata format """
+        data = [{
+            "task_key": "407fdd93-687a-46bb-b578-89eb96b4109d",
+            "datapoint_uri": "https://domain.com/file1.jpg",
+            "datapoint_hash": "f4acbe8562907183a484498ba901bfe5c5503aaa"
+        },
+                {
+                    "task_key": "20bd4f3e-4518-4602-b67a-1d8dfabcce0c",
+                    "datapoint_uri": "https://domain.com/file2.jpg",
+                    "datapoint_hash": "f4acbe8562907183a484498ba901bfe5c5503aaa"
+                }]
+
+        self.validate_taskdata(data)
+
+    def test_taskdata_invalid_uuid(self):
+        """ should raise for invalid task_key """
+        data = [{
+            "task_key": "not_uuid",
+            "datapoint_uri": "https://domain.com/file2.jpg",
+            "datapoint_hash": "f4acbe8562907183a484498ba901bfe5c5503aaa"
+        }]
+
+        with self.assertRaises(schematics.exceptions.DataError):
+            self.validate_taskdata(data)
+
+    def test_taskdata_invalid_uri(self):
+        """ should raise for invalid datapoint_uri """
+        data = [{
+            "task_key": "20bd4f3e-4518-4602-b67a-1d8dfabcce0c",
+            "datapoint_uri": "not_url",
+            "datapoint_hash": "f4acbe8562907183a484498ba901bfe5c5503aaa"
+        }]
+
+        with self.assertRaises(schematics.exceptions.DataError):
+            self.validate_taskdata(data)
+
+    def test_taskdata_missing_fields(self):
+        """ should raise for missing fields """
+        data = [{}]
+
+        with self.assertRaises(schematics.exceptions.DataError):
+            self.validate_taskdata(data)
+
+
+@httpretty.activate
+class TestValidateManifestUris(unittest.TestCase):
+    def register_http_response(self, uri="https://uri.com", manifest=None, body=None):
+        httpretty.register_uri(httpretty.GET, uri, body=json.dumps(body))
+
+    def test_no_uris(self):
+        """ should not raise if there are no uris to validate """
+        manifest = {}
+        basemodels.validate_manifest_uris(manifest)
+
+    def test_groundtruth_uri_valid(self):
+        uri = "https://uri.com"
+        manifest = {"groundtruth_uri": uri, "request_type": "image_label_binary"}
+        body = {
+            "https://domain.com/123/file1.jpeg": ["false", "false", "false"],
+            "https://domain.com/456/file2.jpeg": ["false", "true", "false"],
+        }
+
+        self.register_http_response(uri, manifest, body)
+
+        basemodels.validate_manifest_uris(manifest)
+
+    def test_groundtruth_uri_invalid(self):
+        uri = "https://uri.com"
+        manifest = {"groundtruth_uri": uri, "request_type": "image_label_binary"}
+        body = {"not_uri": ["false", "false", True]}
+
+        self.register_http_response(uri, manifest, body)
+
+        with self.assertRaises(schematics.exceptions.DataError):
+            basemodels.validate_manifest_uris(manifest)
+
+    def test_taskdata_uri_valid(self):
+        uri = "https://uri.com"
+        manifest = {"taskdata_uri": uri}
+        body = [{
+            "task_key": "407fdd93-687a-46bb-b578-89eb96b4109d",
+            "datapoint_uri": "https://domain.com/file1.jpg",
+            "datapoint_hash": "f4acbe8562907183a484498ba901bfe5c5503aaa"
+        },
+                {
+                    "task_key": "20bd4f3e-4518-4602-b67a-1d8dfabcce0c",
+                    "datapoint_uri": "https://domain.com/file2.jpg",
+                    "datapoint_hash": "f4acbe8562907183a484498ba901bfe5c5503aaa"
+                }]
+
+        self.register_http_response(uri, manifest, body)
+
+        basemodels.validate_manifest_uris(manifest)
+
+    def test_taskdata_uri_invalid(self):
+        uri = "https://uri.com"
+        manifest = {"taskdata_uri": uri}
+        body = [{"task_key": "not_uuid", "datapoint_uri": "not_uri"}]
+
+        self.register_http_response(uri, manifest, body)
+
+        with self.assertRaises(schematics.exceptions.DataError):
+            basemodels.validate_manifest_uris(manifest)
+
+    def test_multi_challenge_manifests_valid(self):
+        uri = "https://uri.com"
+        manifest = {"multi_challenge_manifests": [{"taskdata_uri": uri}]}
+        body = [{
+            "task_key": "407fdd93-687a-46bb-b578-89eb96b4109d",
+            "datapoint_uri": "https://domain.com/file1.jpg",
+            "datapoint_hash": "f4acbe8562907183a484498ba901bfe5c5503aaa"
+        }]
+
+        self.register_http_response(uri, manifest, body)
+
+        basemodels.validate_manifest_uris(manifest)
+
+    def test_multi_challenge_manifests_invalid(self):
+        uri = "https://uri.com"
+        manifest = {"multi_challenge_manifests": [{"taskdata_uri": uri}]}
+        body = [{
+            "datapoint_uri": 5,
+        }]
+
+        self.register_http_response(uri, manifest, body)
+
+        with self.assertRaises(schematics.exceptions.DataError):
+            basemodels.validate_manifest_uris(manifest)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #30

ToDo:
- [x] TaskData Model


Top level dict with dynamic keys appeared to be quite tricky with `schematics`, have to rely on factory function and wrap such gt data like `ILBGroundtruth({"items": data})`
I can potentially switch to marshmallow (I see it its used for VIA atm), it provides the way to validate unknown fields and it could also handle top level arrays which could be useful for TaskData, but then we will kinda have to deal with different validation APIs for related things

If current approach is ok, Ill add TaskData model in a similar way