### PR TITLE
Add mitl to internal config

### DIFF
--- a/basemodels/manifest/manifest.py
+++ b/basemodels/manifest/manifest.py
@@ -85,6 +85,7 @@ class InternalConfig(Model):
     reco = DictType(StringType, UnionType([StringType, IntType, FloatType]))
     repo = DictType(StringType, UnionType([StringType, IntType, FloatType]))
     other = DictType(StringType, UnionType([StringType, IntType, FloatType]))
+    mitl = DictType(StringType, UnionType([StringType, IntType, FloatType]))
 
 
 class NestedManifest(Model):

--- a/basemodels/manifest/manifest.py
+++ b/basemodels/manifest/manifest.py
@@ -5,7 +5,7 @@ from typing import Dict, Callable, Any, Union
 from schematics.models import Model, ValidationError
 from schematics.exceptions import BaseError
 from schematics.types import StringType, DecimalType, BooleanType, IntType, DictType, ListType, URLType, FloatType, \
-    UUIDType, ModelType, BooleanType, UnionType, NumberType
+    UUIDType, ModelType, BooleanType, UnionType, NumberType, BaseType
 
 from .data.groundtruth import validate_groundtruth_entry
 from .data.taskdata import validate_taskdata_entry
@@ -85,7 +85,8 @@ class InternalConfig(Model):
     reco = DictType(StringType, UnionType([StringType, IntType, FloatType]))
     repo = DictType(StringType, UnionType([StringType, IntType, FloatType]))
     other = DictType(StringType, UnionType([StringType, IntType, FloatType]))
-    mitl = DictType(StringType, UnionType([StringType, IntType, FloatType]))
+    # Accept any type of data
+    mitl = BaseType()
 
 
 class NestedManifest(Model):

--- a/basemodels/manifest/manifest.py
+++ b/basemodels/manifest/manifest.py
@@ -85,8 +85,17 @@ class InternalConfig(Model):
     reco = DictType(StringType, UnionType([StringType, IntType, FloatType]))
     repo = DictType(StringType, UnionType([StringType, IntType, FloatType]))
     other = DictType(StringType, UnionType([StringType, IntType, FloatType]))
-    # Accept any type of data
-    mitl = BaseType()
+    # Accept one layer of nested
+    mitl = DictType(
+        UnionType(
+            [
+                StringType,
+                IntType,
+                FloatType,
+                DictType(UnionType([StringType, IntType, FloatType])),
+            ]
+        )
+    )
 
 
 class NestedManifest(Model):

--- a/bin/shell
+++ b/bin/shell
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -exu
+
+cd $(dirname $0)/..
+docker-compose build
+docker-compose run basemodels bash

--- a/bin/shell
+++ b/bin/shell
@@ -3,4 +3,4 @@ set -exu
 
 cd $(dirname $0)/..
 docker-compose build
-docker-compose run basemodels bash
+docker-compose run --rm basemodels bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,3 +2,5 @@ version: '2'
 services:
   basemodels:
     build: .
+    volumes:
+      - ./:/work

--- a/test.py
+++ b/test.py
@@ -585,6 +585,29 @@ class TestValidateManifestUris(unittest.TestCase):
 
         basemodels.validate_manifest_uris(manifest)
 
+    def test_mitl_in_internal_config(self):
+        """ Test that mitl config can be part of the internal configuration """
+        model = a_manifest().to_primitive()
+        mitl_config = {
+            "n_gt": 200,
+            "min_tasks_in_job": 1000,
+            "n_gt_sample_min": 1,
+            "n_gt_sample_max": 3,
+            "task_max_repeats": 25,
+            "max_tasks_in_job": 36000,
+            "model_id": "ResNext50_32x4d",
+            "task_selection_id": "MinMargin",
+            "requester_min_repeats": 12,
+            "requester_max_repeats": 25,
+            "stop_n_active": 1000,
+            "requester_accuracy_target": 0.8
+        }
+
+        model["internal_config"] = {**model["internal_config"], "mitl": mitl_config}
+        manifest = basemodels.Manifest(model)
+        manifest.validate()
+        self.assertTrue(True)
+
 
 if __name__ == "__main__":
     logging.basicConfig()

--- a/test.py
+++ b/test.py
@@ -600,7 +600,11 @@ class TestValidateManifestUris(unittest.TestCase):
             "requester_min_repeats": 12,
             "requester_max_repeats": 25,
             "stop_n_active": 1000,
-            "requester_accuracy_target": 0.8
+            "requester_accuracy_target": 0.8,
+            "nested_config": {
+                "value_a": 1,
+                "value_b": 2
+            }
         }
 
         model["internal_config"] = {**model["internal_config"], "mitl": mitl_config}

--- a/test.py
+++ b/test.py
@@ -607,7 +607,7 @@ class TestValidateManifestUris(unittest.TestCase):
             }
         }
 
-        model["internal_config"] = {**model["internal_config"], "mitl": mitl_config}
+        model["internal_config"]["mitl"] = mitl_config
         manifest = basemodels.Manifest(model)
         manifest.validate()
         self.assertTrue(True)


### PR DESCRIPTION
@gaieges I can't get floattype to work. Do you have any idea why it fails?

With this setup I get:
```
schematics.exceptions.DataError: {"internal_config": {"mitl": {"requester_accuracy_target": ["Couldn't interpret '0.8' as string."]}}}
```

Same happens if I add floats to exchange configuration. Internal config is defined as 
```
class InternalConfig(Model):
    """ discarded from incoming manifests """
    exchange = DictType(StringType, UnionType([StringType, IntType, FloatType]))
    reco = DictType(StringType, UnionType([StringType, IntType, FloatType]))
    repo = DictType(StringType, UnionType([StringType, IntType, FloatType]))
    other = DictType(StringType, UnionType([StringType, IntType, FloatType]))
    mitl = DictType(StringType, UnionType([StringType, IntType, FloatType]))
```

I'm quite surprised that it doesn't work. 