### PR TITLE
fix pypi 'Could not restore untracked files from stash entry'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ script:
 - "./bin/ci"
 
 deploy:
+  skip_cleanup: true
+  skip_existing: true
   provider: pypi
   user: dev-im
   # This edge argument is intended to work around issue:


### PR DESCRIPTION
Travis failed with this error:

```
Could not restore untracked files from stash entry
PyPI upload failed.
failed to deploy
```

These changes should fix it. Based on https://github.com/lyft/awspricing/pull/46