### PR TITLE
Add ability to toggle answer encryption on blockchain

### DIFF
--- a/basemodels/manifest/data/taskdata.py
+++ b/basemodels/manifest/data/taskdata.py
@@ -10,24 +10,18 @@ class TaskDataEntry(Model):
       {
         "task_key": "407fdd93-687a-46bb-b578-89eb96b4109d",
         "datapoint_uri": "https://domain.com/file1.jpg",
-        "datapoint_text": "",
-        "is_text_question": False,
         "datapoint_hash": "f4acbe8562907183a484498ba901bfe5c5503aaa"
       },
       {
         "task_key": "20bd4f3e-4518-4602-b67a-1d8dfabcce0c",
-        "datapoint_uri": "",
-        "datapoint_text": "any question here",
-        "is_text_question": True,
+        "datapoint_uri": "https://domain.com/file2.jpg",
         "datapoint_hash": "f4acbe8562907183a484498ba901bfe5c5503aaa"
       }
     ]
     """
     task_key = UUIDType()
-    datapoint_uri = URLType()
-    datapoint_text = StringType()
+    datapoint_uri = URLType(required=True, min_length=10)
     datapoint_hash = StringType()
-    is_text_question = BooleanType()
     metadata = DictType(
       UnionType([
         StringType(required=False, max_length=256),
@@ -39,19 +33,6 @@ class TaskDataEntry(Model):
     def validate_metadata(self, data, value):
         if len(str(value)) > 1024:
             raise ValidationError("metadata should be < 1024")
-        return value
-
-    def validate_datapoint_text(self, data, value):
-        if data.get('is_text_question') and not value:
-            raise ValidationError("datapoint_text is missing.")
-        return value
-
-    def validate_datapoint_uri(self, data, value):
-        if not data.get('is_text_question'):
-            if not value:
-                raise ValidationError("datapoint_uri is missing.")
-            if len(value) < 10:
-                raise ValidationError("datapoint_uri length is less than 10")
         return value
 
 

--- a/basemodels/manifest/manifest.py
+++ b/basemodels/manifest/manifest.py
@@ -63,23 +63,8 @@ class Webhook(Model):
 class TaskData(Model):
     """ objects within taskdata list in Manifest """
     task_key = UUIDType(required=True)
-    datapoint_uri = URLType()
+    datapoint_uri = URLType(required=True, min_length=10)
     datapoint_hash = StringType(required=True, min_length=10)
-    datapoint_text = StringType()
-    is_text_question = BooleanType()
-
-    def validate_datapoint_text(self, data, value):
-        if data.get('is_text_question') and not value:
-            raise ValidationError("datapoint_text is missing.")
-        return value
-
-    def validate_datapoint_uri(self, data, value):
-        if not data.get('is_text_question'):
-            if not value:
-                raise ValidationError("datapoint_uri is missing.")
-            if len(value) < 10:
-                raise ValidationError("datapoint_uri length is less than 10")
-        return value
 
 
 class RequestConfig(Model):

--- a/basemodels/manifest/manifest.py
+++ b/basemodels/manifest/manifest.py
@@ -183,6 +183,7 @@ class Manifest(Model):
     job_id = UUIDType(default=uuid.uuid4)
     job_total_tasks = IntType(required=True)
     network = StringType(required=False)
+    only_sign_results = BooleanType(default=False,)
 
     requester_restricted_answer_set = DictType(DictType(StringType))
 

--- a/basemodels/pydantic/manifest/manifest.py
+++ b/basemodels/pydantic/manifest/manifest.py
@@ -212,6 +212,7 @@ class Manifest(Model):
     multi_challenge_manifests: Optional[List[NestedManifest]]
     request_type: BaseJobTypesEnum
     network: Optional[str]
+    only_sign_results: bool = False
 
     requester_restricted_answer_set: Optional[Dict[str, Dict[str, str]]]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hmt-basemodels"
-version = "0.1.13"
+version = "0.1.14"
 description = ""
 authors = ["Intuition Machines, Inc <support@hcaptcha.com>"]
 packages = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hmt-basemodels"
-version = "0.1.14"
+version = "0.1.15"
 description = ""
 authors = ["Intuition Machines, Inc <support@hcaptcha.com>"]
 packages = [

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="hmt-basemodels",
-    version="0.1.13",
+    version="0.1.14",
     author="HUMAN Protocol",
     description="Common data models shared by various components of the Human Protocol stack",
     url="https://github.com/hCaptcha/hmt-basemodels",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="hmt-basemodels",
-    version="0.1.14",
+    version="0.1.15",
     author="HUMAN Protocol",
     description="Common data models shared by various components of the Human Protocol stack",
     url="https://github.com/hCaptcha/hmt-basemodels",

--- a/tests/both_models.py
+++ b/tests/both_models.py
@@ -164,8 +164,6 @@ def a_nested_manifest(
 TASK = {
     "task_key": "407fdd93-687a-46bb-b578-89eb96b4109d",
     "datapoint_uri": "https://domain.com/file1.jpg",
-    "datapoint_text": "",
-    "is_text_question": False,
     "datapoint_hash": "f4acbe8562907183a484498ba901bfe5c5503aaa",
     "metadata": {
         "key_1": "value_1",
@@ -901,24 +899,7 @@ class TaskEntryTest(unittest.TestCase):
         taskdata.pop("metadata")
         self.assertIsNone(TaskDataEntry(taskdata).validate())
 
-        with self.assertRaises(schematics.exceptions.DataError):
-            taskdata['is_text_question'] = True
-            invalid = TaskDataEntry(taskdata).validate()
 
-        taskdata['datapoint_text'] = "Question to test with"
-        self.assertIsNone(TaskDataEntry(taskdata).validate())
-
-        with self.assertRaises(schematics.exceptions.DataError):
-            taskdata['is_text_question'] = False
-            taskdata['datapoint_uri'] = ""
-            invalid = TaskDataEntry(taskdata).validate()
-
-        with self.assertRaises(schematics.exceptions.DataError):
-            taskdata['datapoint_uri'] = "http://com"
-            invalid = TaskDataEntry(taskdata).validate()
-
-        taskdata['datapoint_uri'] = "https://domain.com/file1.jpg"
-        self.assertIsNone(TaskDataEntry(taskdata).validate())
 
 
 if __name__ == "__main__":

--- a/tests/both_models.py
+++ b/tests/both_models.py
@@ -598,7 +598,7 @@ class ManifestTest(unittest.TestCase):
         validate_func(create_manifest(manifest))()
 
     def test_default_only_sign_results(self):
-        """ Test whether flat 'only_sign_results' is False by default. """
+        """ Test whether flag 'only_sign_results' is False by default. """
         manifest = a_manifest()
         self.assertEqual(manifest.only_sign_results, False)
 

--- a/tests/both_models.py
+++ b/tests/both_models.py
@@ -173,6 +173,7 @@ TASK = {
     }
 }
 
+
 class ManifestTest(unittest.TestCase):
     """Manifest specific tests, validating that models work the way we want"""
 
@@ -598,6 +599,11 @@ class ManifestTest(unittest.TestCase):
         del manifest["requester_question_example"]
         validate_func(create_manifest(manifest))()
 
+    def test_default_only_sign_results(self):
+        """ Test whether flat 'only_sign_results' is False by default. """
+        manifest = a_manifest()
+        self.assertEqual(manifest.only_sign_results, False)
+
 
 class ViaTest(unittest.TestCase):
     def test_via_legacy_case(self):
@@ -913,10 +919,6 @@ class TaskEntryTest(unittest.TestCase):
 
         taskdata['datapoint_uri'] = "https://domain.com/file1.jpg"
         self.assertIsNone(TaskDataEntry(taskdata).validate())
-
-
-
-
 
 
 if __name__ == "__main__":

--- a/tests/test_pydantic.py
+++ b/tests/test_pydantic.py
@@ -30,7 +30,7 @@ SIMPLE = {
             {"dfe03e7c-f417-4726-8b14-ae033a3cc66e": {"score": 1}},
             {"dfe03e7c-f417-4726-8b12-ae033a3cc66a": {"score": 1}},
         ]
-    },
+    }
 }
 
 TASK = {
@@ -82,3 +82,7 @@ class PydanticTest(TestCase):
         taskdata.pop("metadata")
         TaskDataEntry(**taskdata)
 
+    def test_default_only_sign_results(self):
+        """ Test whether flat 'only_sign_results' is False by default. """
+        manifest = Manifest(**self.m)
+        self.assertEqual(manifest.only_sign_results, False)


### PR DESCRIPTION
Flag 'only_sign_results' supported to provide support to decision whether result data in blockchain must be only signed instead of signed and encrypted.