### PR TITLE
IMI-2282 - feat: adding field to support storing final results publicly

### DIFF
--- a/basemodels/manifest/manifest.py
+++ b/basemodels/manifest/manifest.py
@@ -176,7 +176,7 @@ class Manifest(Model):
     job_total_tasks = IntType(required=True)
     network = StringType(required=False)
     only_sign_results = BooleanType(default=False,)
-    store_pub_final_results = BooleanType(default=False,)
+    public_results = BooleanType(default=False,)
 
     requester_restricted_answer_set = DictType(DictType(StringType))
 

--- a/basemodels/manifest/manifest.py
+++ b/basemodels/manifest/manifest.py
@@ -169,6 +169,7 @@ class Manifest(Model):
     job_total_tasks = IntType(required=True)
     network = StringType(required=False)
     only_sign_results = BooleanType(default=False,)
+    store_pub_final_results = BooleanType(default=False,)
 
     requester_restricted_answer_set = DictType(DictType(StringType))
 

--- a/basemodels/pydantic/manifest/manifest.py
+++ b/basemodels/pydantic/manifest/manifest.py
@@ -213,6 +213,7 @@ class Manifest(Model):
     request_type: BaseJobTypesEnum
     network: Optional[str]
     only_sign_results: bool = False
+    store_pub_final_results: bool = False
 
     requester_restricted_answer_set: Optional[Dict[str, Dict[str, str]]]
 

--- a/basemodels/pydantic/manifest/manifest.py
+++ b/basemodels/pydantic/manifest/manifest.py
@@ -214,7 +214,7 @@ class Manifest(Model):
     request_type: BaseJobTypesEnum
     network: Optional[str]
     only_sign_results: bool = False
-    store_pub_final_results: bool = False
+    public_results: bool = False
 
     requester_restricted_answer_set: Optional[Dict[str, Dict[str, str]]]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hmt-basemodels"
-version = "0.1.15"
+version = "0.1.16"
 description = ""
 authors = ["Intuition Machines, Inc <support@hcaptcha.com>"]
 packages = [

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="hmt-basemodels",
-    version="0.1.15",
+    version="0.1.16",
     author="HUMAN Protocol",
     description="Common data models shared by various components of the Human Protocol stack",
     url="https://github.com/hCaptcha/hmt-basemodels",

--- a/tests/both_models.py
+++ b/tests/both_models.py
@@ -602,6 +602,11 @@ class ManifestTest(unittest.TestCase):
         manifest = a_manifest()
         self.assertEqual(manifest.only_sign_results, False)
 
+    def test_default_store_pub_final_results(self):
+        """ Test whether flag 'store_pub_final_results' is False by default. """
+        manifest = a_manifest()
+        self.assertEqual(manifest.store_pub_final_results, False)
+
 
 class ViaTest(unittest.TestCase):
     def test_via_legacy_case(self):


### PR DESCRIPTION
Adding field `public_results` in Manifest model to support this option to store final results when not encrypted.

IMI-2282