### PR TITLE
Imi 2934 add datapoint text to task data

### DIFF
--- a/basemodels/manifest/data/taskdata.py
+++ b/basemodels/manifest/data/taskdata.py
@@ -10,24 +10,21 @@ class TaskDataEntry(Model):
       {
         "task_key": "407fdd93-687a-46bb-b578-89eb96b4109d",
         "datapoint_uri": "https://domain.com/file1.jpg",
-        "datapoint_text": "",
-        "is_text_question": False,
+        "datapoint_text": {},
         "datapoint_hash": "f4acbe8562907183a484498ba901bfe5c5503aaa"
       },
       {
         "task_key": "20bd4f3e-4518-4602-b67a-1d8dfabcce0c",
         "datapoint_uri": "",
-        "datapoint_text": "any question here",
-        "is_text_question": True,
+        "datapoint_text": { "en": "any question here"},
         "datapoint_hash": "f4acbe8562907183a484498ba901bfe5c5503aaa"
       }
     ]
     """
     task_key = UUIDType()
     datapoint_uri = URLType()
-    datapoint_text = StringType()
+    datapoint_text = DictType(StringType(), StringType())
     datapoint_hash = StringType()
-    is_text_question = BooleanType()
     metadata = DictType(
       UnionType([
         StringType(required=False, max_length=256),
@@ -41,17 +38,16 @@ class TaskDataEntry(Model):
             raise ValidationError("metadata should be < 1024")
         return value
 
-    def validate_datapoint_text(self, data, value):
-        if data.get('is_text_question') and not value:
-            raise ValidationError("datapoint_text is missing.")
-        return value
-
     def validate_datapoint_uri(self, data, value):
-        if not data.get('is_text_question'):
-            if not value:
-                raise ValidationError("datapoint_uri is missing.")
-            if len(value) < 10:
-                raise ValidationError("datapoint_uri length is less than 10")
+        """
+        Validate datapoint_uri.
+
+        Raise error if no datapoint_text and no value for URI or if length of URI less than 10.
+        """
+        if not value and not data.get('datapoint_text'):
+            raise ValidationError("datapoint_uri is missing.")
+        if len(value) < 10:
+            raise ValidationError("datapoint_uri length is less than 10")
         return value
 
 

--- a/basemodels/manifest/data/taskdata.py
+++ b/basemodels/manifest/data/taskdata.py
@@ -50,7 +50,7 @@ class TaskDataEntry(Model):
         """
         if not value and not data.get('datapoint_text'):
             raise ValidationError("datapoint_uri is missing.")
-        if len(value) < 10:
+        if value and len(value) < 10 and not data.get('datapoint_text'):
             raise ValidationError("datapoint_uri length is less than 10")
         return value
 

--- a/basemodels/manifest/manifest.py
+++ b/basemodels/manifest/manifest.py
@@ -65,20 +65,18 @@ class TaskData(Model):
     task_key = UUIDType(required=True)
     datapoint_uri = URLType()
     datapoint_hash = StringType(required=True, min_length=10)
-    datapoint_text = StringType()
-    is_text_question = BooleanType()
-
-    def validate_datapoint_text(self, data, value):
-        if data.get('is_text_question') and not value:
-            raise ValidationError("datapoint_text is missing.")
-        return value
+    datapoint_text = DictType(StringType, StringType)
 
     def validate_datapoint_uri(self, data, value):
-        if not data.get('is_text_question'):
-            if not value:
-                raise ValidationError("datapoint_uri is missing.")
-            if len(value) < 10:
-                raise ValidationError("datapoint_uri length is less than 10")
+        """
+        Validate datapoint_uri.
+
+        Raise error if no datapoint_text and no value for URI or if length of URI less than 10.
+        """
+        if not value and not data.get('datapoint_text'):
+            raise ValidationError("datapoint_uri is missing.")
+        if len(value) < 10:
+            raise ValidationError("datapoint_uri length is less than 10")
         return value
 
 

--- a/basemodels/manifest/manifest.py
+++ b/basemodels/manifest/manifest.py
@@ -75,7 +75,7 @@ class TaskData(Model):
         """
         if not value and not data.get('datapoint_text'):
             raise ValidationError("datapoint_uri is missing.")
-        if len(value) < 10:
+        if value and len(value) < 10 and not data.get('datapoint_text'):
             raise ValidationError("datapoint_uri length is less than 10")
         return value
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="hmt-basemodels",
-    version="0.1.19",
+    version="0.1.20",
     author="HUMAN Protocol",
     description="Common data models shared by various components of the Human Protocol stack",
     url="https://github.com/hCaptcha/hmt-basemodels",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="hmt-basemodels",
-    version="0.1.20",
+    version="0.1.21",
     author="HUMAN Protocol",
     description="Common data models shared by various components of the Human Protocol stack",
     url="https://github.com/hCaptcha/hmt-basemodels",

--- a/tests/both_models.py
+++ b/tests/both_models.py
@@ -164,8 +164,7 @@ def a_nested_manifest(
 TASK = {
     "task_key": "407fdd93-687a-46bb-b578-89eb96b4109d",
     "datapoint_uri": "https://domain.com/file1.jpg",
-    "datapoint_text": "",
-    "is_text_question": False,
+    "datapoint_text": {},
     "datapoint_hash": "f4acbe8562907183a484498ba901bfe5c5503aaa",
     "metadata": {
         "key_1": "value_1",
@@ -895,15 +894,11 @@ class TaskEntryTest(unittest.TestCase):
         taskdata.pop("metadata")
         self.assertIsNone(TaskDataEntry(taskdata).validate())
 
-        with self.assertRaises(schematics.exceptions.DataError):
-            taskdata['is_text_question'] = True
-            invalid = TaskDataEntry(taskdata).validate()
-
-        taskdata['datapoint_text'] = "Question to test with"
+        taskdata['datapoint_text'] = {"en": "Question to test with"}
         self.assertIsNone(TaskDataEntry(taskdata).validate())
 
         with self.assertRaises(schematics.exceptions.DataError):
-            taskdata['is_text_question'] = False
+            taskdata['datapoint_text'] = {}
             taskdata['datapoint_uri'] = ""
             invalid = TaskDataEntry(taskdata).validate()
 


### PR DESCRIPTION
Update Validation for taskdata to accommodate  datapoint_text.

This change will make `datapoint_uri` only required when there is no `datapoint_text` in the taskdata.