### PR TITLE
update types accepted for requester_question_example

### DIFF
--- a/basemodels/manifest/manifest.py
+++ b/basemodels/manifest/manifest.py
@@ -146,7 +146,7 @@ class NestedManifest(Model):
 
     requester_question_example = UnionType((URLType, ListType), field=URLType)
 
-    requester_question_example_extra = UnionType([
+    requester_example_extra_fields = UnionType([
         DictType(StringType), ListType(DictType(StringType))
     ], required=False)
 
@@ -216,7 +216,7 @@ class Manifest(Model):
 
     requester_question_example = UnionType((URLType, ListType), field=URLType)
 
-    requester_question_example_extra = UnionType([
+    requester_example_extra_fields = UnionType([
         DictType(StringType), ListType(DictType(StringType))
     ])
 

--- a/basemodels/manifest/manifest.py
+++ b/basemodels/manifest/manifest.py
@@ -144,9 +144,11 @@ class NestedManifest(Model):
     requester_min_repeats = IntType(default=1)
     requester_question = DictType(StringType)
 
-    requester_question_example = UnionType([
-        URLType, DictType(StringType), ListType(UnionType([URLType, DictType(StringType)]))
-    ])
+    requester_question_example = UnionType((URLType, ListType), field=URLType)
+
+    requester_question_example_extra = UnionType([
+        DictType(StringType), ListType(DictType(StringType))
+    ], required=False)
 
     def validate_requester_question_example(self, data, value):
         # validation runs before other params, so need to handle missing case
@@ -155,12 +157,6 @@ class NestedManifest(Model):
 
         # based on https://github.com/hCaptcha/hmt-basemodels/issues/27#issuecomment-590706643
         supports_lists = ['image_label_area_select', 'image_label_binary']
-
-        supports_dicts = [
-            'image_label_area_select',
-        ]
-        if isinstance(value, dict) and not data['request_type'] in supports_dicts:
-            raise ValidationError("Dicts are not allowed in this challenge type")
 
         if isinstance(value, list) and not data['request_type'] in supports_lists:
             raise ValidationError("Lists are not allowed in this challenge type")
@@ -218,8 +214,10 @@ class Manifest(Model):
     requester_min_repeats = IntType(default=1)
     requester_question = DictType(StringType)
 
-    requester_question_example = UnionType([
-        URLType, DictType(StringType), ListType(UnionType([URLType, DictType(StringType)]))
+    requester_question_example = UnionType((URLType, ListType), field=URLType)
+
+    requester_question_example_extra = UnionType([
+        DictType(StringType), ListType(DictType(StringType))
     ])
 
     def validate_requester_question_example(self, data, value):
@@ -229,12 +227,6 @@ class Manifest(Model):
 
         # based on https://github.com/hCaptcha/hmt-basemodels/issues/27#issuecomment-590706643
         supports_lists = ['image_label_area_select', 'image_label_binary']
-
-        supports_dicts = [
-            'image_label_area_select',
-        ]
-        if isinstance(value, dict) and not data['request_type'] in supports_dicts:
-            raise ValidationError("Dicts are not allowed in this challenge type")
 
         if isinstance(value, list) and not data['request_type'] in supports_lists:
             raise ValidationError("Lists are not allowed in this challenge type")

--- a/basemodels/manifest/manifest.py
+++ b/basemodels/manifest/manifest.py
@@ -144,7 +144,9 @@ class NestedManifest(Model):
     requester_min_repeats = IntType(default=1)
     requester_question = DictType(StringType)
 
-    requester_question_example = UnionType((URLType, ListType), field=URLType)
+    requester_question_example = UnionType([
+        URLType, DictType(StringType), ListType(UnionType([URLType, DictType(StringType)]))
+    ])
 
     def validate_requester_question_example(self, data, value):
         # validation runs before other params, so need to handle missing case
@@ -153,6 +155,12 @@ class NestedManifest(Model):
 
         # based on https://github.com/hCaptcha/hmt-basemodels/issues/27#issuecomment-590706643
         supports_lists = ['image_label_area_select', 'image_label_binary']
+
+        supports_dicts = [
+            'image_label_area_select',
+        ]
+        if isinstance(value, dict) and not data['request_type'] in supports_dicts:
+            raise ValidationError("Dicts are not allowed in this challenge type")
 
         if isinstance(value, list) and not data['request_type'] in supports_lists:
             raise ValidationError("Lists are not allowed in this challenge type")
@@ -210,7 +218,9 @@ class Manifest(Model):
     requester_min_repeats = IntType(default=1)
     requester_question = DictType(StringType)
 
-    requester_question_example = UnionType((URLType, ListType), field=URLType)
+    requester_question_example = UnionType([
+        URLType, DictType(StringType), ListType(UnionType([URLType, DictType(StringType)]))
+    ])
 
     def validate_requester_question_example(self, data, value):
         # validation runs before other params, so need to handle missing case
@@ -219,6 +229,12 @@ class Manifest(Model):
 
         # based on https://github.com/hCaptcha/hmt-basemodels/issues/27#issuecomment-590706643
         supports_lists = ['image_label_area_select', 'image_label_binary']
+
+        supports_dicts = [
+            'image_label_area_select',
+        ]
+        if isinstance(value, dict) and not data['request_type'] in supports_dicts:
+            raise ValidationError("Dicts are not allowed in this challenge type")
 
         if isinstance(value, list) and not data['request_type'] in supports_lists:
             raise ValidationError("Lists are not allowed in this challenge type")

--- a/basemodels/pydantic/manifest/manifest.py
+++ b/basemodels/pydantic/manifest/manifest.py
@@ -230,7 +230,8 @@ class Manifest(Model):
     requester_min_repeats: int = 1
     requester_question: Optional[Dict[str, str]]
 
-    requester_question_example: Optional[Union[HttpUrl, Dict[str, str], List[Union[HttpUrl, Dict[str, str]]]]]
+    requester_question_example: Optional[Union[HttpUrl, List[HttpUrl]]]
+    requester_question_example_extra: Optional[Union[Dict[str, str], List[Union[Dict[str, str]]]]]
 
     unsafe_content: bool = False
     task_bid_price: float
@@ -316,13 +317,6 @@ class Manifest(Model):
             BaseJobTypesEnum.image_label_area_select,
             BaseJobTypesEnum.image_label_binary,
         ]
-
-        supports_dict = [
-            BaseJobTypesEnum.image_label_area_select,
-        ]
-
-        if isinstance(value, dict) and not (values["request_type"] in supports_dict):
-            raise ValueError("Dicts are not allowed in this challenge type")
 
         if isinstance(value, list) and not (values["request_type"] in supports_lists):
             raise ValueError("Lists are not allowed in this challenge type")

--- a/basemodels/pydantic/manifest/manifest.py
+++ b/basemodels/pydantic/manifest/manifest.py
@@ -231,7 +231,7 @@ class Manifest(Model):
     requester_question: Optional[Dict[str, str]]
 
     requester_question_example: Optional[Union[HttpUrl, List[HttpUrl]]]
-    requester_question_example_extra: Optional[Union[Dict[str, str], List[Union[Dict[str, str]]]]]
+    requester_example_extra_fields: Optional[Union[Dict[str, str], List[Union[Dict[str, str]]]]]
 
     unsafe_content: bool = False
     task_bid_price: float

--- a/basemodels/pydantic/manifest/manifest.py
+++ b/basemodels/pydantic/manifest/manifest.py
@@ -230,7 +230,7 @@ class Manifest(Model):
     requester_min_repeats: int = 1
     requester_question: Optional[Dict[str, str]]
 
-    requester_question_example: Optional[Union[HttpUrl, List[HttpUrl]]]
+    requester_question_example: Optional[Union[HttpUrl, Dict[str, str], List[Union[HttpUrl, Dict[str, str]]]]]
 
     unsafe_content: bool = False
     task_bid_price: float
@@ -316,6 +316,13 @@ class Manifest(Model):
             BaseJobTypesEnum.image_label_area_select,
             BaseJobTypesEnum.image_label_binary,
         ]
+
+        supports_dict = [
+            BaseJobTypesEnum.image_label_area_select,
+        ]
+
+        if isinstance(value, dict) and not (values["request_type"] in supports_dict):
+            raise ValueError("Dicts are not allowed in this challenge type")
 
         if isinstance(value, list) and not (values["request_type"] in supports_lists):
             raise ValueError("Lists are not allowed in this challenge type")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hmt-basemodels"
-version = "0.1.18"
+version = "0.1.23"
 description = ""
 authors = ["Intuition Machines, Inc <support@hcaptcha.com>"]
 packages = [

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="hmt-basemodels",
-    version="0.1.22",
+    version="0.1.23",
     author="HUMAN Protocol",
     description="Common data models shared by various components of the Human Protocol stack",
     url="https://github.com/hCaptcha/hmt-basemodels",

--- a/tests/both_models.py
+++ b/tests/both_models.py
@@ -601,6 +601,13 @@ class ManifestTest(unittest.TestCase):
         del manifest["requester_question_example"]
         validate_func(create_manifest(manifest))()
 
+        manifest["requester_question_example"] = {"answer_example_uri": FAKE_URL, "answer_example_coords": "coords"}
+        with self.assertRaises(validation_base_errors[test_mode]):
+            validate_func(create_manifest(manifest))()
+
+        manifest['request_type'] = "image_label_area_select"
+        validate_func(create_manifest(manifest))()
+
     def test_default_only_sign_results(self):
         """ Test whether flag 'only_sign_results' is False by default. """
         manifest = a_manifest()

--- a/tests/both_models.py
+++ b/tests/both_models.py
@@ -601,11 +601,17 @@ class ManifestTest(unittest.TestCase):
         del manifest["requester_question_example"]
         validate_func(create_manifest(manifest))()
 
-        manifest["requester_question_example"] = {"answer_example_uri": FAKE_URL, "answer_example_coords": "coords"}
-        with self.assertRaises(validation_base_errors[test_mode]):
-            validate_func(create_manifest(manifest))()
-
+        manifest["requester_question_example_extra"] = {
+            "answer_example_uri": FAKE_URL,
+            "answer_example_coords": "coords"
+        }
         manifest['request_type'] = "image_label_area_select"
+        validate_func(create_manifest(manifest))()
+
+        manifest["requester_question_example_extra"] = [{
+            "answer_example_uri": FAKE_URL,
+            "answer_example_coords": "coords"
+        }]
         validate_func(create_manifest(manifest))()
 
     def test_default_only_sign_results(self):

--- a/tests/both_models.py
+++ b/tests/both_models.py
@@ -601,14 +601,14 @@ class ManifestTest(unittest.TestCase):
         del manifest["requester_question_example"]
         validate_func(create_manifest(manifest))()
 
-        manifest["requester_question_example_extra"] = {
+        manifest["requester_example_extra_fields"] = {
             "answer_example_uri": FAKE_URL,
             "answer_example_coords": "coords"
         }
         manifest['request_type'] = "image_label_area_select"
         validate_func(create_manifest(manifest))()
 
-        manifest["requester_question_example_extra"] = [{
+        manifest["requester_example_extra_fields"] = [{
             "answer_example_uri": FAKE_URL,
             "answer_example_coords": "coords"
         }]


### PR DESCRIPTION
Have a new optional field `requester_question_example_extra` that will be used for jobs that need to add extra processing the `requester_question_example` urls