### PR TITLE
project: bump version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "hmt-basemodels"
-version = "0.1.25"
+version = "0.1.26"
 description = ""
 authors = ["Intuition Machines, Inc <support@hcaptcha.com>"]
 packages = [


### PR DESCRIPTION
In #89 I bumped the version in `setup.py`, looking at the other commits bumping version I see I missed the `pyproject.toml`.
Fixing it here.